### PR TITLE
更新图片地址，修复github pages 页面中无法显示的问题

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -74,4 +74,4 @@ sequelize.sync()
 请通过 [Getting started - 入门](getting-started.md) 来学习更多相关内容。 如果你想要学习 Sequelize API 请通过 [API Reference](http://docs.sequelizejs.com/identifiers) (英文)。
 
 # 赞赏支持
-![赞赏支持](https://github.com/demopark/electron-api-demos-Zh_CN/blob/master/assets/img/td.png)
+![赞赏支持](https://raw.githubusercontent.com/demopark/electron-api-demos-Zh_CN/master/assets/img/td.png)


### PR DESCRIPTION
现在底部赞赏无法显示 https://demopark.github.io/sequelize-docs-Zh-CN/
![image](https://user-images.githubusercontent.com/23056320/52772144-c9b50700-3072-11e9-83f7-df86ea2111b9.png)
