### PR TITLE
修改歧义部分

### DIFF
--- a/core-concepts/model-basics.md
+++ b/core-concepts/model-basics.md
@@ -67,7 +67,7 @@ User.init({
   }
 }, {
   // 这是其他模型参数
-  sequelize, // 我们需要传递连接实例
+  sequelize, // 我们需要传递连接实例 (缩写) 相当于 sequlize:sequlize
   modelName: 'User' // 我们需要选择模型名称
 });
 


### PR DESCRIPTION
告诉使用者这是ES6的变量缩写，根据ES6标准 当传递参数名称和被传递变量名称相同时，可以只写一次名称。
例： foo ={bar:bar}  (缩写) foo={bar} 

文档没有写明这是传递参数缩写，这会迷惑到ES6新手，甚至ES6老手。
