### PR TITLE
Fix：新增 TINYINT 数据类型

### DIFF
--- a/core-concepts/model-basics.md
+++ b/core-concepts/model-basics.md
@@ -282,6 +282,8 @@ DataTypes.BOOLEAN            // TINYINT(1)
 ### 数字
 
 ```js
+DataTypes.TINYINT            // TINYINT
+
 DataTypes.INTEGER            // INTEGER
 DataTypes.BIGINT             // BIGINT
 DataTypes.BIGINT(11)         // BIGINT(11)


### PR DESCRIPTION
开发中 TINYINT 类型在定义字段时经常使用，文档上应该需要进行补充完善。